### PR TITLE
refactor: add sources

### DIFF
--- a/sora/cli.py
+++ b/sora/cli.py
@@ -4,7 +4,7 @@ import os
 
 import typer
 
-from sora.anime import Anime
+from sora.sources import *  # noqa: F403
 
 app = typer.Typer()
 
@@ -48,8 +48,10 @@ def download(
         if not episodes:
             episodes = "all"
     path = path or os.getcwd()
-    anime = Anime(url, path)
-    anime.download(episodes, quality)
+    sources = [WitAnimeSource]  # noqa: F405
+    for source in sources:
+        anime_source = source(url, path)
+        anime_source.download(episodes, quality)
 
 
 @app.command()

--- a/sora/downloaders.py
+++ b/sora/downloaders.py
@@ -7,6 +7,7 @@ from io import BytesIO
 import httpx
 from bs4 import BeautifulSoup as Bs
 
+from sora.exceptions import EpisodeNotDownloaded
 from sora.utils import get_random_name
 
 
@@ -47,7 +48,10 @@ class MediafireDownloader(BaseDownloader):
         with GzipFile(fileobj=BytesIO(compressed_data)) as f:
             html = f.read().decode("utf-8")
             soup = Bs(html, "lxml")
-            direct_download_url = soup.find("a", {"id": "downloadButton"}).attrs["href"]
+            direct_download_url = soup.find("a", {"id": "downloadButton"})
+            if direct_download_url is None:
+                raise EpisodeNotDownloaded("Didn't find the direct url from mediafire")
+            direct_download_url = direct_download_url.attrs["href"]
             conn = http.client.HTTPConnection(parsed_url.netloc)
             conn.request(
                 "GET",

--- a/sora/exceptions.py
+++ b/sora/exceptions.py
@@ -1,0 +1,2 @@
+class EpisodeNotDownloaded(Exception):
+    pass

--- a/sora/sources/__init__.py
+++ b/sora/sources/__init__.py
@@ -1,0 +1,3 @@
+from .witanime import WitAnimeSource
+
+__all__ = ["WitAnimeSource"]

--- a/sora/sources/base.py
+++ b/sora/sources/base.py
@@ -1,0 +1,53 @@
+from sora.anime import Episode
+
+import httpx
+
+
+class BaseSource:
+    # The source will simply take the input params (url, path ...etc)
+    # have the download method that will download the episode/s.
+    def __init__(self, url, path) -> None:
+        self.url = url
+        self.path = path
+        self.client = httpx.Client()
+        self.info = self.get_anime_info()
+
+    def get_anime_info(self):
+        raise NotImplementedError()
+
+    def get_episodes_urls(self, episodes):
+        raise NotImplementedError()
+
+    def download(self, episodes, quality=None):
+        quality = quality or 2
+        episodes_urls = self.get_episodes_urls(episodes)
+        for url in episodes_urls:
+            episode = Episode(url, self.path, client=self.client)
+            print("Downloading {}".format(episode.info["title"]))
+            episode.download(quality)
+
+    @property
+    def title(self):
+        return self.info["title"]
+
+    @property
+    def indirect_urls(self):
+        return self.info["indirect_urls"]
+
+    @property
+    def episodes_number(self):
+        return self.info["episodes_number"]
+
+
+class BaseEpisode:
+    def __init__(self, url, path=None, client=None) -> None:
+        self.url = url
+        self.path = path
+        self.client = client or httpx.Client()
+        self.info = self.get_episode_info()
+
+    def get_episode_info(self):
+        raise NotImplementedError()
+
+    def download(self, quality_number):
+        raise NotImplementedError()


### PR DESCRIPTION
Before this PR we had the `Anime` class that is responsible for getting the episodes and information about the anime and the `Eposide` class that represents an episode and has some information about one episode and we had the downloaders (currently we only have a downloader for mediafire but we plan to add more in the future) and the downloaders were responsible for downloading the episodes.

This architecture is working just fine for now but we have a problem. What if we want to download from another source ? we may need this if 1) One of the sources changed how they protect their content (witanime did this recently) and 2) if a source doesn't have an anime or maybe one episode is missing because of copyright violations and stuff like that.

So this is what will happen right now. We will have some sources that inherits the `BaseSource` and every source will have it's own `Episode` that inherits the `BaseEpisode` class. And then we will loop over these sources and download the episode from the first source if we couldn't do this because of any of the reasons mentioned above then we will do it from the second source and so on.

In the future when we add a config file we may allow users to choose the arrangement of the sources and maybe exclude sources and many other things as well.